### PR TITLE
Fix ATO last run and duration resets

### DIFF
--- a/custom_components/reef_pi/__init__.py
+++ b/custom_components/reef_pi/__init__.py
@@ -213,8 +213,18 @@ class ReefPiDataUpdateCoordinator(DataUpdateCoordinator):
             atos = {a['id']: a for a in atos}
             ato_states = {}
             for id in atos.keys():
-                ato_states[id] = await self.api.ato(id)
-                ato_states[id]['ts'] = datetime.strptime(ato_states[id]['time'], REEFPI_DATETIME_FORMAT)
+                states = await self.api.ato(id)
+                ato_state = [s for s in states if s['pump'] != 0]
+                if len(ato_state) > 0:
+                    ato_states[id] = ato_state[-1]
+                    ato_states[id]['ts'] = datetime.strptime(ato_states[id]['time'], REEFPI_DATETIME_FORMAT)
+                elif id not in ato_states.keys():
+                    if len(states) > 0:
+                        ato_states[id] = states[-1]
+                        ato_states[id]['ts'] = datetime.strptime(ato_states[id]['time'], REEFPI_DATETIME_FORMAT)
+                    else:
+                        ato_states[id] = {'ts': datetime.fromtimestamp(0), 'pump': 0}
+                    
             self.ato = atos
             self.ato_states = ato_states
 

--- a/custom_components/reef_pi/async_api.py
+++ b/custom_components/reef_pi/async_api.py
@@ -113,9 +113,9 @@ class ReefApi:
     async def ato(self, id):
         readings = await self._get(f"atos/{id}/usage")
         if readings and "current" in readings.keys() and len(readings['current']):
-            return readings['current'][-1]
+            return readings['current']
         if readings and "historical" in readings.keys() and len(readings['historical']):
-            return readings['historical'][-1]
+            return readings['historical']
         return None
 
     async def ato_update(self, id, enable):

--- a/custom_components/reef_pi/manifest.json
+++ b/custom_components/reef_pi/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "reef_pi",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "name": "Reef PI Integration",
   "config_flow": true,
   "documentation": "https://github.com/tdragon/reef-pi-hass-custom",

--- a/custom_components/reef_pi/switch.py
+++ b/custom_components/reef_pi/switch.py
@@ -134,13 +134,13 @@ class ReefPiAtoSwitch(CoordinatorEntity, SwitchEntity):
         """Turn the entity on."""
         await self.api.ato_update(self._id, True)
         self.api.ato[self._id]["enable"] = True
-        self.schedule_update_ha_state(True)
+        self.schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity on."""
         await self.api.ato_update(self._id, False)
         self.api.ato[self._id]["enable"] = False
-        self.schedule_update_ha_state(True)
+        self.schedule_update_ha_state()
 
     @property
     def extra_state_attributes(self):

--- a/tests/async_api_mock.py
+++ b/tests/async_api_mock.py
@@ -137,7 +137,7 @@ def mock_atos(mock, url = REEF_MOCK_URL):
             "disable_on_alert":False,
             "one_shot":False}])
 
-    mock.get(f'{url}/api/atos/1/usage').respond(200, json = {"current":[{"pump":120,"time":"Jan-11-09:01, 2022"}]})
+    mock.get(f'{url}/api/atos/1/usage').respond(200, json = {"current":[{"pump":120,"time":"Jan-11-09:01, 2022"}, {"pump":0,"time":"Jan-12-09:01, 2022"}]})
 
 def mock_all(mock, url = REEF_MOCK_URL, has_ph = True):
         mock_signin(mock)

--- a/tests/async_api_tests.py
+++ b/tests/async_api_tests.py
@@ -60,6 +60,8 @@ async def test_atos(reef_pi_instance):
     assert '1' == info[0]['id']
 
     usage = await reef.ato(1)
-    assert 120 == usage['pump']
+    assert 0 == usage[-1]['pump']
+    assert 120 == usage[0]['pump']
+
 
 


### PR DESCRIPTION
ATO usage reports every time ATO checks the sensor even. The integration
will report last time when the pump was not 0.