### PR TITLE
feat(light): add color_mode property to ReefPiLight

### DIFF
--- a/custom_components/reef_pi/light.py
+++ b/custom_components/reef_pi/light.py
@@ -71,6 +71,11 @@ class ReefPiLight(CoordinatorEntity, LightEntity):
         """Flag supported color modes."""
         return {ColorMode.BRIGHTNESS}
 
+    @property
+    def color_mode(self) -> str | None:
+        """Return the color mode of the light."""
+        return ColorMode.BRIGHTNESS
+
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
         await self.api.light_control(self._id, 0)

--- a/custom_components/reef_pi/manifest.json
+++ b/custom_components/reef_pi/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "httpx>=0.21.0"
   ],
-  "version": "0.3.11"
+  "version": "0.3.12"
 }

--- a/tests/async_api_mock.py
+++ b/tests/async_api_mock.py
@@ -16,7 +16,7 @@ def mock_capabilities(mock, ph=True, url=REEF_MOCK_URL):
             "health_check": False,
             "equipment": True,
             "timers": False,
-            "lighting": False,
+            "lighting": True,
             "temperature": True,
             "ato": True,
             "camera": False,
@@ -122,6 +122,25 @@ def mock_atos(mock, url=REEF_MOCK_URL, empty_usage=False):
         )
 
 
+def mock_lights(mock, url=REEF_MOCK_URL):
+    mock.get(f"{url}/api/lights").respond(
+        200,
+        json=[
+            {
+                "id": "1",
+                "channels": {
+                    "red": {
+                        "manual": True,
+                        "name": "Red",
+                        "value": 0.5,
+                    }
+                },
+                "name": "ReefPi Light",
+            },
+        ],
+    )
+
+
 def mock_all(mock, url=REEF_MOCK_URL, has_ph=True, has_ato_usage=True):
     mock_signin(mock)
     mock_capabilities(mock)
@@ -130,6 +149,7 @@ def mock_all(mock, url=REEF_MOCK_URL, has_ph=True, has_ato_usage=True):
     mock_ph6(mock)
     mock_ph78(mock)
     mock_atos(mock, empty_usage=not has_ato_usage)
+    mock_lights(mock)
 
     mock.get(f"{url}/api/doser/pumps").respond(
         200,


### PR DESCRIPTION
- Added `color_mode` property to `ReefPiLight` class to return the color mode of the light.
- Updated version in `manifest.json` to `0.3.12`.
- Enabled `lighting` capability in `mock_capabilities`.
- Added `mock_lights` function to mock light API responses in tests.

Fix: #31 